### PR TITLE
refactor(build): prune empty translation units from algoat target

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,13 @@
-add_library(algoat algoat.cpp core/traits.cpp core/config.cpp core/registry.cpp core/dispatcher.cpp sorting/insertionsort.cpp sorting/quicksort.cpp sorting/mergesort.cpp sorting/heapsort.cpp searching/linear_search.cpp searching/binary_search.cpp searching/interpolation_search.cpp)
+add_library(algoat
+    algoat.cpp
+    core/config.cpp
+    core/dispatcher.cpp
+    sorting/quicksort.cpp
+    sorting/mergesort.cpp
+    sorting/heapsort.cpp
+    searching/binary_search.cpp
+    searching/interpolation_search.cpp
+)
 
 target_include_directories(algoat
     PUBLIC

--- a/src/core/registry.cpp
+++ b/src/core/registry.cpp
@@ -1,8 +1,0 @@
-/**
- * @file registry.cpp
- * @brief Source unit for Registry template instantiations.
- *
- * The Registry class template implementation resides entirely in @c algoat/core/registry.hpp.
- */
-
-#include "algoat/core/registry.hpp"

--- a/src/core/traits.cpp
+++ b/src/core/traits.cpp
@@ -1,8 +1,0 @@
-/**
- * @file traits.cpp
- * @brief Source unit for DataTraits implementations.
- *
- * The analyze() algorithm implementation resides in @c algoat/core/traits.hpp.
- */
-
-#include "algoat/core/traits.hpp"

--- a/src/searching/linear_search.cpp
+++ b/src/searching/linear_search.cpp
@@ -1,1 +1,0 @@
-#include "algoat/searching/linear_search.hpp"

--- a/src/sorting/insertionsort.cpp
+++ b/src/sorting/insertionsort.cpp
@@ -1,1 +1,0 @@
-#include "algoat/sorting/insertionsort.hpp"


### PR DESCRIPTION
## Summary

Fixed the issue by updating `src/CMakeLists.txt` to exclude the four header-only `.cpp` stubs from the build.

### Validation

* CMake configure succeeded
* Release build succeeded
* All 178 tests passed

Could you please have a look and let me know if this implementation is good? If you think anything can be improved or changed, I'd be happy to make the necessary updates.

Closes #8

## Screenshot (Test Passed):
<img width="1565" height="932" alt="{848706FB-E0AE-4214-A05B-5BB6B5DE0C98}" src="https://github.com/user-attachments/assets/470e8008-437a-465f-a804-ce5962e54d1a" />


