### PR TITLE
fix(python): isolate GC and list cloning in Python benchmark harness

### DIFF
--- a/benchmarks/bench_python.py
+++ b/benchmarks/bench_python.py
@@ -1,6 +1,18 @@
 import timeit
+import gc
 import numpy as np
 import algoat
+
+def bench_op(sort_fn, data, number=10):
+    """Run sort_fn on pre-allocated copies of data with isolated GC."""
+    copies = [data.copy() for _ in range(number)]
+    gc.collect()
+    gc.disable()
+    total_time = 0.0
+    for copy in copies:
+        total_time += timeit.timeit(lambda: sort_fn(copy), number=1)
+    gc.enable()
+    return total_time
 
 def benchmark_sorting():
     sizes = [10_000, 100_000, 1_000_000]
@@ -13,8 +25,8 @@ def benchmark_sorting():
         # require 'A' so it's memory aligned, just in case
         arr_f16_aligned = np.require(arr_f16, requirements=['A'])
 
-        t_np_f16 = timeit.timeit(lambda: np.sort(arr_f16_aligned), number=10)
-        t_algoat_f16 = timeit.timeit(lambda: algoat.sort(arr_f16_aligned), number=10)
+        t_np_f16 = bench_op(np.sort, arr_f16_aligned, number=10)
+        t_algoat_f16 = bench_op(algoat.sort, arr_f16_aligned, number=10)
 
         print(f"Float16 np.sort:     {t_np_f16:.4f} s")
         print(f"Float16 algoat.sort: {t_algoat_f16:.4f} s")
@@ -25,8 +37,8 @@ def benchmark_sorting():
         # np.sort on complex arrays sorts by real part, then imaginary part.
         arr_c64 = (np.random.rand(size) + 1j * np.random.rand(size)).astype(np.complex64)
 
-        t_np_c64 = timeit.timeit(lambda: np.sort(arr_c64), number=10)
-        t_algoat_c64 = timeit.timeit(lambda: algoat.sort(arr_c64), number=10)
+        t_np_c64 = bench_op(np.sort, arr_c64, number=10)
+        t_algoat_c64 = bench_op(algoat.sort, arr_c64, number=10)
 
         print(f"Complex64 np.sort:     {t_np_c64:.4f} s")
         print(f"Complex64 algoat.sort: {t_algoat_c64:.4f} s")
@@ -35,8 +47,8 @@ def benchmark_sorting():
         # 3. Boolean sorting
         arr_bool = np.random.choice([False, True], size=size)
 
-        t_np_bool = timeit.timeit(lambda: np.sort(arr_bool), number=10)
-        t_algoat_bool = timeit.timeit(lambda: algoat.sort(arr_bool), number=10)
+        t_np_bool = bench_op(np.sort, arr_bool, number=10)
+        t_algoat_bool = bench_op(algoat.sort, arr_bool, number=10)
 
         print(f"Bool np.sort:     {t_np_bool:.4f} s")
         print(f"Bool algoat.sort: {t_algoat_bool:.4f} s")
@@ -44,3 +56,4 @@ def benchmark_sorting():
 
 if __name__ == '__main__':
     benchmark_sorting()
+

--- a/benchmarks/bench_python.py
+++ b/benchmarks/bench_python.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 import gc
 import statistics
 import time
-from typing import Any, Callable, Dict
+from typing import Any, Callable
 
 import algoat
 import numpy as np
@@ -24,7 +24,7 @@ def bench_sort(
     data: np.ndarray,
     number: int = 10,
     warmup: int = 3,
-) -> Dict[str, float]:
+) -> dict[str, float]:
     """Run sort_fn on pre-allocated copies of data with isolated GC."""
     # Warmup phase
     for _ in range(warmup):
@@ -109,5 +109,3 @@ def benchmark_sorting():
 
 if __name__ == '__main__':
     benchmark_sorting()
-
-

--- a/benchmarks/bench_python.py
+++ b/benchmarks/bench_python.py
@@ -1,18 +1,52 @@
-import timeit
+from contextlib import contextmanager
 import gc
-import numpy as np
-import algoat
+import statistics
+import time
+from typing import Any, Callable, Dict
 
-def bench_op(sort_fn, data, number=10):
-    """Run sort_fn on pre-allocated copies of data with isolated GC."""
-    copies = [data.copy() for _ in range(number)]
+import algoat
+import numpy as np
+
+
+@contextmanager
+def disabled_gc():
+    """Context manager to collect and disable GC during benchmark measurements."""
     gc.collect()
     gc.disable()
-    total_time = 0.0
-    for copy in copies:
-        total_time += timeit.timeit(lambda: sort_fn(copy), number=1)
-    gc.enable()
-    return total_time
+    try:
+        yield
+    finally:
+        gc.enable()
+
+
+def bench_sort(
+    sort_fn: Callable[[np.ndarray], Any],
+    data: np.ndarray,
+    number: int = 10,
+    warmup: int = 3,
+) -> Dict[str, float]:
+    """Run sort_fn on pre-allocated copies of data with isolated GC."""
+    # Warmup phase
+    for _ in range(warmup):
+        sort_fn(data.copy())
+
+    # Pre-allocate copies for measurement phase
+    copies = [data.copy() for _ in range(number)]
+
+    times_sec: list[float] = []
+    with disabled_gc():
+        for copy in copies:
+            t0 = time.perf_counter_ns()
+            sort_fn(copy)
+            t1 = time.perf_counter_ns()
+            times_sec.append((t1 - t0) / 1e9)
+
+    min_val = min(times_sec)
+    median_val = statistics.median(times_sec)
+    mad_val = statistics.median([abs(x - median_val) for x in times_sec])
+
+    return {"min": min_val, "median": median_val, "mad": mad_val}
+
 
 def benchmark_sorting():
     sizes = [10_000, 100_000, 1_000_000]
@@ -25,35 +59,55 @@ def benchmark_sorting():
         # require 'A' so it's memory aligned, just in case
         arr_f16_aligned = np.require(arr_f16, requirements=['A'])
 
-        t_np_f16 = bench_op(np.sort, arr_f16_aligned, number=10)
-        t_algoat_f16 = bench_op(algoat.sort, arr_f16_aligned, number=10)
+        stats_np_f16 = bench_sort(np.sort, arr_f16_aligned, number=10)
+        stats_algoat_f16 = bench_sort(algoat.sort, arr_f16_aligned, number=10)
 
-        print(f"Float16 np.sort:     {t_np_f16:.4f} s")
-        print(f"Float16 algoat.sort: {t_algoat_f16:.4f} s")
-        print(f"Speedup:             {t_np_f16 / t_algoat_f16:.2f}x")
+        print(
+            f"Float16 np.sort:     min={stats_np_f16['min']:.6f}s, "
+            f"median={stats_np_f16['median']:.6f}s, mad={stats_np_f16['mad']:.6f}s"
+        )
+        print(
+            f"Float16 algoat.sort: min={stats_algoat_f16['min']:.6f}s, "
+            f"median={stats_algoat_f16['median']:.6f}s, mad={stats_algoat_f16['mad']:.6f}s"
+        )
+        print(f"Speedup (median):    {stats_np_f16['median'] / stats_algoat_f16['median']:.2f}x")
 
         # 2. Complex64 sorting (Morton Z-order)
         # numpy doesn't naturally sort complex like we do (we use Morton), but we can still benchmark speed.
         # np.sort on complex arrays sorts by real part, then imaginary part.
         arr_c64 = (np.random.rand(size) + 1j * np.random.rand(size)).astype(np.complex64)
 
-        t_np_c64 = bench_op(np.sort, arr_c64, number=10)
-        t_algoat_c64 = bench_op(algoat.sort, arr_c64, number=10)
+        stats_np_c64 = bench_sort(np.sort, arr_c64, number=10)
+        stats_algoat_c64 = bench_sort(algoat.sort, arr_c64, number=10)
 
-        print(f"Complex64 np.sort:     {t_np_c64:.4f} s")
-        print(f"Complex64 algoat.sort: {t_algoat_c64:.4f} s")
-        print(f"Speedup:               {t_np_c64 / t_algoat_c64:.2f}x")
+        print(
+            f"Complex64 np.sort:     min={stats_np_c64['min']:.6f}s, "
+            f"median={stats_np_c64['median']:.6f}s, mad={stats_np_c64['mad']:.6f}s"
+        )
+        print(
+            f"Complex64 algoat.sort: min={stats_algoat_c64['min']:.6f}s, "
+            f"median={stats_algoat_c64['median']:.6f}s, mad={stats_algoat_c64['mad']:.6f}s"
+        )
+        print(f"Speedup (median):      {stats_np_c64['median'] / stats_algoat_c64['median']:.2f}x")
 
         # 3. Boolean sorting
         arr_bool = np.random.choice([False, True], size=size)
 
-        t_np_bool = bench_op(np.sort, arr_bool, number=10)
-        t_algoat_bool = bench_op(algoat.sort, arr_bool, number=10)
+        stats_np_bool = bench_sort(np.sort, arr_bool, number=10)
+        stats_algoat_bool = bench_sort(algoat.sort, arr_bool, number=10)
 
-        print(f"Bool np.sort:     {t_np_bool:.4f} s")
-        print(f"Bool algoat.sort: {t_algoat_bool:.4f} s")
-        print(f"Speedup:          {t_np_bool / t_algoat_bool:.2f}x")
+        print(
+            f"Bool np.sort:     min={stats_np_bool['min']:.6f}s, "
+            f"median={stats_np_bool['median']:.6f}s, mad={stats_np_bool['mad']:.6f}s"
+        )
+        print(
+            f"Bool algoat.sort: min={stats_algoat_bool['min']:.6f}s, "
+            f"median={stats_algoat_bool['median']:.6f}s, mad={stats_algoat_bool['mad']:.6f}s"
+        )
+        print(f"Speedup (median): {stats_np_bool['median'] / stats_algoat_bool['median']:.2f}x")
+
 
 if __name__ == '__main__':
     benchmark_sorting()
+
 

--- a/examples/python/benchmark.py
+++ b/examples/python/benchmark.py
@@ -7,13 +7,14 @@ across varying dataset sizes.
 
 import bisect
 from contextlib import contextmanager
+import functools
 import gc
 import operator
 import random
 import statistics
 import sys
 import time
-from typing import Any, Callable, List
+from typing import Any, Callable
 
 if hasattr(sys.stdout, 'reconfigure'):
     sys.stdout.reconfigure(encoding='utf-8')
@@ -52,8 +53,8 @@ def bench(fn: Callable[[], Any], *, warmup: int = 3, runs: int = 50) -> dict[str
 
 
 def bench_sort(
-    sort_fn: Callable[[List[Any]], Any],
-    data: List[Any],
+    sort_fn: Callable[[list[Any]], Any],
+    data: list[Any],
     *,
     warmup: int = 3,
     runs: int = 50,
@@ -97,15 +98,15 @@ def run_sort_benchmarks(sizes):
     for n in sizes:
         data = generate_data(n)
 
-        s_algoat = bench_sort(algoat.sort, data)
-        s_inplace = bench_sort(algoat.sort_inplace, data)
-        s_sorted = bench_sort(sorted, data)
-        s_listsort = bench_sort(operator.methodcaller("sort"), data)
+        stats_algoat = bench_sort(algoat.sort, data)
+        stats_inplace = bench_sort(algoat.sort_inplace, data)
+        stats_sorted = bench_sort(sorted, data)
+        stats_listsort = bench_sort(operator.methodcaller("sort"), data)
 
-        t_algoat = s_algoat["median"]
-        t_inplace = s_inplace["median"]
-        t_sorted = s_sorted["median"]
-        t_listsort = s_listsort["median"]
+        t_algoat = stats_algoat["median"]
+        t_inplace = stats_inplace["median"]
+        t_sorted = stats_sorted["median"]
+        t_listsort = stats_listsort["median"]
 
         # Compare inplace to list.sort()
         ratio = t_inplace / t_listsort if t_listsort > 0 else float('inf')
@@ -131,22 +132,22 @@ def run_search_benchmarks(sizes):
         # Pick a target we know exists
         target = sorted_data[n // 3]
 
-        # algoat.search on sorted data
-        s_algoat = bench(lambda: algoat.search(sorted_data, target))
+        # algoat.search on sorted data via functools.partial to eliminate closure overhead
+        stats_algoat = bench(functools.partial(algoat.search, sorted_data, target))
 
         # bisect (binary search) on sorted data
         def bisect_search():
             idx = bisect.bisect_left(sorted_data, target)
             return idx if idx < len(sorted_data) and sorted_data[idx] == target else None
 
-        s_bisect = bench(bisect_search)
+        stats_bisect = bench(bisect_search)
 
-        # list.index (linear scan)
-        s_index = bench(lambda: sorted_data.index(target))
+        # list.index (linear scan) via functools.partial to eliminate closure overhead
+        stats_index = bench(functools.partial(sorted_data.index, target))
 
-        t_algoat = s_algoat["median"]
-        t_bisect = s_bisect["median"]
-        t_index = s_index["median"]
+        t_algoat = stats_algoat["median"]
+        t_bisect = stats_bisect["median"]
+        t_index = stats_index["median"]
 
         ratio = t_algoat / t_bisect if t_bisect > 0 else float('inf')
         results.append((n, t_algoat, t_bisect, t_index, ratio))

--- a/examples/python/benchmark.py
+++ b/examples/python/benchmark.py
@@ -1,50 +1,44 @@
-#!/usr/bin/env python3
-"""Algoat vs Python Native — Performance Benchmark
-
-Compares algoat's C++ backed sort/search against Python builtins
-across varying dataset sizes.
-"""
-
-import time
+import bisect
+from contextlib import contextmanager
+import gc
+import operator
 import random
 import statistics
-import bisect
-import gc
+import time
+from typing import Any, Callable, Iterable
+
 import algoat
 
 
-def bench(fn, *, warmup=3, runs=50):
-    """Run fn() `runs` times after warmup with isolated GC, return median time in µs."""
-    for _ in range(warmup):
-        fn()
+@contextmanager
+def disabled_gc():
+    """Context manager to collect and disable GC during benchmark measurements."""
     gc.collect()
     gc.disable()
-    times = []
-    for _ in range(runs):
-        t0 = time.perf_counter_ns()
-        fn()
-        t1 = time.perf_counter_ns()
-        times.append((t1 - t0) / 1_000)  # ns → µs
-    gc.enable()
-    return statistics.median(times)
+    try:
+        yield
+    finally:
+        gc.enable()
 
 
-def bench_sort(sort_fn, data, *, warmup=3, runs=50):
-    """Run sort_fn on pre-allocated copies of data with isolated GC, return median time in µs."""
-    for _ in range(warmup):
-        sort_fn(data.copy())
+def bench(action_fn: Callable[[Any], Any], items: Iterable[Any], *, warmup: int = 3) -> float:
+    """Run action_fn on items after warmup with isolated GC, returning median latency in µs."""
+    items_list = list(items)
+    if not items_list:
+        return 0.0
 
-    copies = [data.copy() for _ in range(runs)]
+    # Warmup phase
+    for i in range(min(warmup, len(items_list))):
+        action_fn(items_list[i])
 
-    gc.collect()
-    gc.disable()
-    times = []
-    for copy in copies:
-        t0 = time.perf_counter_ns()
-        sort_fn(copy)
-        t1 = time.perf_counter_ns()
-        times.append((t1 - t0) / 1_000)  # ns → µs
-    gc.enable()
+    times: list[float] = []
+    with disabled_gc():
+        for item in items_list:
+            t0 = time.perf_counter_ns()
+            action_fn(item)
+            t1 = time.perf_counter_ns()
+            times.append((t1 - t0) / 1_000)  # ns → µs
+
     return statistics.median(times)
 
 
@@ -64,10 +58,10 @@ def run_sort_benchmarks(sizes):
     for n in sizes:
         data = generate_data(n)
 
-        t_algoat = bench_sort(algoat.sort, data)
-        t_inplace = bench_sort(algoat.sort_inplace, data)
-        t_sorted = bench_sort(sorted, data)
-        t_listsort = bench_sort(lambda d: d.sort(), data)
+        t_algoat = bench(algoat.sort, (data.copy() for _ in range(50)))
+        t_inplace = bench(algoat.sort_inplace, (data.copy() for _ in range(50)))
+        t_sorted = bench(sorted, (data.copy() for _ in range(50)))
+        t_listsort = bench(operator.methodcaller("sort"), (data.copy() for _ in range(50)))
 
         # Compare inplace to list.sort()
         ratio = t_inplace / t_listsort if t_listsort > 0 else float('inf')

--- a/examples/python/benchmark.py
+++ b/examples/python/benchmark.py
@@ -11,8 +11,12 @@ import gc
 import operator
 import random
 import statistics
+import sys
 import time
-from typing import Any, Callable, Iterable
+from typing import Any, Callable, List
+
+if hasattr(sys.stdout, 'reconfigure'):
+    sys.stdout.reconfigure(encoding='utf-8')
 
 import algoat
 
@@ -28,25 +32,53 @@ def disabled_gc():
         gc.enable()
 
 
-def bench(action_fn: Callable[[Any], Any], items: Iterable[Any], *, warmup: int = 3) -> float:
-    """Run action_fn on items after warmup with isolated GC, returning median latency in µs."""
-    items_list = list(items)
-    if not items_list:
-        return 0.0
-
-    # Warmup phase
-    for i in range(min(warmup, len(items_list))):
-        action_fn(items_list[i])
-
+def bench(fn: Callable[[], Any], *, warmup: int = 3, runs: int = 50) -> dict[str, float]:
+    """Run zero-argument fn() `runs` times after warmup with isolated GC, returning min/median/MAD latencies in µs."""
+    for _ in range(warmup):
+        fn()
     times: list[float] = []
     with disabled_gc():
-        for item in items_list:
+        for _ in range(runs):
             t0 = time.perf_counter_ns()
-            action_fn(item)
+            fn()
             t1 = time.perf_counter_ns()
             times.append((t1 - t0) / 1_000)  # ns → µs
 
-    return statistics.median(times)
+    min_val = min(times)
+    median_val = statistics.median(times)
+    mad_val = statistics.median([abs(x - median_val) for x in times])
+
+    return {"min": min_val, "median": median_val, "mad": mad_val}
+
+
+def bench_sort(
+    sort_fn: Callable[[List[Any]], Any],
+    data: List[Any],
+    *,
+    warmup: int = 3,
+    runs: int = 50,
+) -> dict[str, float]:
+    """Run sort_fn on pre-allocated copies of data with isolated GC, returning min/median/MAD latencies in µs."""
+    if data:
+        for _ in range(warmup):
+            sample = data.copy()
+            sort_fn(sample)
+
+    copies = [data.copy() for _ in range(runs)]
+
+    times: list[float] = []
+    with disabled_gc():
+        for copy in copies:
+            t0 = time.perf_counter_ns()
+            sort_fn(copy)
+            t1 = time.perf_counter_ns()
+            times.append((t1 - t0) / 1_000)  # ns → µs
+
+    min_val = min(times)
+    median_val = statistics.median(times)
+    mad_val = statistics.median([abs(x - median_val) for x in times])
+
+    return {"min": min_val, "median": median_val, "mad": mad_val}
 
 
 def generate_data(n, seed=42):
@@ -65,10 +97,15 @@ def run_sort_benchmarks(sizes):
     for n in sizes:
         data = generate_data(n)
 
-        t_algoat = bench(algoat.sort, (data.copy() for _ in range(50)))
-        t_inplace = bench(algoat.sort_inplace, (data.copy() for _ in range(50)))
-        t_sorted = bench(sorted, (data.copy() for _ in range(50)))
-        t_listsort = bench(operator.methodcaller("sort"), (data.copy() for _ in range(50)))
+        s_algoat = bench_sort(algoat.sort, data)
+        s_inplace = bench_sort(algoat.sort_inplace, data)
+        s_sorted = bench_sort(sorted, data)
+        s_listsort = bench_sort(operator.methodcaller("sort"), data)
+
+        t_algoat = s_algoat["median"]
+        t_inplace = s_inplace["median"]
+        t_sorted = s_sorted["median"]
+        t_listsort = s_listsort["median"]
 
         # Compare inplace to list.sort()
         ratio = t_inplace / t_listsort if t_listsort > 0 else float('inf')
@@ -95,17 +132,21 @@ def run_search_benchmarks(sizes):
         target = sorted_data[n // 3]
 
         # algoat.search on sorted data
-        t_algoat = bench(lambda: algoat.search(sorted_data, target))
+        s_algoat = bench(lambda: algoat.search(sorted_data, target))
 
         # bisect (binary search) on sorted data
         def bisect_search():
             idx = bisect.bisect_left(sorted_data, target)
             return idx if idx < len(sorted_data) and sorted_data[idx] == target else None
 
-        t_bisect = bench(bisect_search)
+        s_bisect = bench(bisect_search)
 
         # list.index (linear scan)
-        t_index = bench(lambda: sorted_data.index(target))
+        s_index = bench(lambda: sorted_data.index(target))
+
+        t_algoat = s_algoat["median"]
+        t_bisect = s_bisect["median"]
+        t_index = s_index["median"]
 
         ratio = t_algoat / t_bisect if t_bisect > 0 else float('inf')
         results.append((n, t_algoat, t_bisect, t_index, ratio))
@@ -117,8 +158,8 @@ def run_search_benchmarks(sizes):
 
 def main():
     print("╔══════════════════════════════════════════════════════════════════════╗")
-    print("║         Algoat vs Python Native — Performance Benchmark            ║")
-    print("║         Median of 50 runs per size (3 warmup iterations)           ║")
+    print("║         Algoat vs Python Native — Performance Benchmark              ║")
+    print("║         Median of 50 runs per size (3 warmup iterations)             ║")
     print("╚══════════════════════════════════════════════════════════════════════╝")
     print()
 

--- a/examples/python/benchmark.py
+++ b/examples/python/benchmark.py
@@ -1,3 +1,10 @@
+#!/usr/bin/env python3
+"""Algoat vs Python Native — Performance Benchmark
+
+Compares algoat's C++ backed sort/search against Python builtins
+across varying dataset sizes.
+"""
+
 import bisect
 from contextlib import contextmanager
 import gc

--- a/examples/python/benchmark.py
+++ b/examples/python/benchmark.py
@@ -9,19 +9,42 @@ import time
 import random
 import statistics
 import bisect
+import gc
 import algoat
 
 
 def bench(fn, *, warmup=3, runs=50):
-    """Run fn() `runs` times after warmup, return median time in µs."""
+    """Run fn() `runs` times after warmup with isolated GC, return median time in µs."""
     for _ in range(warmup):
         fn()
+    gc.collect()
+    gc.disable()
     times = []
     for _ in range(runs):
         t0 = time.perf_counter_ns()
         fn()
         t1 = time.perf_counter_ns()
         times.append((t1 - t0) / 1_000)  # ns → µs
+    gc.enable()
+    return statistics.median(times)
+
+
+def bench_sort(sort_fn, data, *, warmup=3, runs=50):
+    """Run sort_fn on pre-allocated copies of data with isolated GC, return median time in µs."""
+    for _ in range(warmup):
+        sort_fn(data.copy())
+
+    copies = [data.copy() for _ in range(runs)]
+
+    gc.collect()
+    gc.disable()
+    times = []
+    for copy in copies:
+        t0 = time.perf_counter_ns()
+        sort_fn(copy)
+        t1 = time.perf_counter_ns()
+        times.append((t1 - t0) / 1_000)  # ns → µs
+    gc.enable()
     return statistics.median(times)
 
 
@@ -41,10 +64,10 @@ def run_sort_benchmarks(sizes):
     for n in sizes:
         data = generate_data(n)
 
-        t_algoat = bench(lambda: algoat.sort(data))
-        t_inplace = bench(lambda: (d := data.copy(), algoat.sort_inplace(d)))
-        t_sorted = bench(lambda: sorted(data))
-        t_listsort = bench(lambda: (d := data.copy(), d.sort()))
+        t_algoat = bench_sort(algoat.sort, data)
+        t_inplace = bench_sort(algoat.sort_inplace, data)
+        t_sorted = bench_sort(sorted, data)
+        t_listsort = bench_sort(lambda d: d.sort(), data)
 
         # Compare inplace to list.sort()
         ratio = t_inplace / t_listsort if t_listsort > 0 else float('inf')


### PR DESCRIPTION
# Pull Request

## Description

Fixes #22

This PR addresses issue #22 by isolating setup overhead—specifically array/list cloning and Garbage Collection (GC) pauses—from actual sorting execution time in our Python benchmark suite (`benchmarks/bench_python.py` and `examples/python/benchmark.py`).

### Root Causes Addressed:
1. **In-place mutation bias**: `algoat.sort()` mutates NumPy arrays in-place. In multi-iteration runs (`timeit`), iteration 1 sorted unsorted data, while iterations 2–10 ran on an already-sorted array. `np.sort()` returns a new copy, sorting unsorted data on every iteration.
2. **Cloning inside timing loops**: List cloning (`data.copy()`) was sitting inside the `perf_counter` closure, counting list allocation/copying cost as sort runtime.
3. **Uncontrolled GC**: Automatic GC was active during benchmarks, adding non-deterministic collection pauses.

---

## Type of Change

- [ ] `feat`: New algorithm, heuristic, or capability
- [x] `fix`: Bug fix
- [ ] `perf`: Performance optimization
- [ ] `refactor`: Code refactoring without behavioral change
- [ ] `docs`: Documentation addition or update
- [ ] `enhance`: Incremental enhancement to existing feature
- [ ] `test`: New or updated tests
- [ ] `chore`: Build system, CI, dependencies, or tooling

---

## Implementation Details

- **Pre-allocation**: All array/list copies are pre-allocated outside timer loops (`copies = [data.copy() for _ in range(runs)]`) so each iteration receives a fresh unsorted input without timing memory allocation.
- **Explicit GC Isolation**: Executed `gc.collect()` before measurements and temporarily disabled GC (`gc.disable()`) during timing runs. Re-enabled GC (`gc.enable()`) after runs finish.
- **Timing Focus**: Benchmarks now measure purely the sorting function calls.

---

## Benchmarks & Performance Metrics (if applicable)

| Benchmark / Dataset | Baseline | Proposed | Speedup |
| :--- | :--- | :--- | :--- |
| Float16 / Complex64 / Bool Benchmarks | Included copy + GC overhead | Isolated sorting time | Accurate & unbiased |

---

## Dependencies

None

---

## Testing & Verification

- [ ] C++ Unit Tests (`ctest --preset debug` or `ctest --test-dir build --output-on-failure`)
- [x] Python Tests (`pytest tests/python/ -v`)
- [ ] Memory & UB Sanitizers (`cmake --preset asan`)
- [x] Custom / Manual test script: `python benchmarks/bench_python.py` & `python examples/python/benchmark.py`

---

## Developer Checklist

- [x] My PR title follows `<Type>(<scope>): <Precise PR deliverable>`.
- [x] My branch was created from `main` using an approved prefix (`feat/`, `fix/`, `perf/`, etc.).
- [x] My code produces no new compiler warnings or static analysis issues.
- [x] I have updated documentation / docstrings where appropriate.
- [x] My changes do not break existing functionality.

---

## Impact Assessment

- [x] **Isolated**: Changes are localized to benchmark scripts and do not affect existing algorithm dispatch or public APIs.
- [ ] **Breaking / Affects Others**: Changes modify public APIs or dispatcher heuristics (explain below).

### Before fixing Benchmark.py, changes
<img width="832" height="728" alt="Screenshot 2026-08-24 093225" src="https://github.com/user-attachments/assets/8abc234b-cf7b-4acf-aac8-2148723e21ef" />

### After fixing Benchmark.py changes
<img width="829" height="759" alt="Screenshot 2026-08-24 091956" src="https://github.com/user-attachments/assets/9dc42a2a-ebeb-4c3a-b663-923ebf981892" />

---
### Before fixing bench_python.py, changes
<img width="734" height="623" alt="Screenshot 2026-08-24 093241" src="https://github.com/user-attachments/assets/c9dfd600-cfaa-4165-bd0d-1154c34a937e" />



### After fixing bench_python.py, changes
<img width="698" height="664" alt="Screenshot 2026-08-24 092122" src="https://github.com/user-attachments/assets/64876dd4-ff5e-4824-b5c2-4c8542849ae5" />

---

## Future Improvements

None

---

## Additional Notes

Opening as a Draft PR to gather feedback from maintainer. 🚀
