### PR TITLE
perf(searching): implement branchless binary search and numpy zero-copy search overloads

### DIFF
--- a/include/algoat/algoat.hpp
+++ b/include/algoat/algoat.hpp
@@ -74,6 +74,10 @@ template <typename T> void sort(std::span<T> data) {
  * std::nullopt.
  */
 template <typename T> std::optional<std::size_t> search(std::span<T> data, const T& target) {
+    return search(std::span<const T>{data.data(), data.size()}, target);
+}
+
+template <typename T> std::optional<std::size_t> search(std::span<const T> data, const T& target) {
     core::Dispatcher dispatcher(get_global_config());
     return dispatcher.search(data, target);
 }

--- a/include/algoat/core/dispatcher.hpp
+++ b/include/algoat/core/dispatcher.hpp
@@ -28,7 +28,7 @@ template <typename Algo, typename T>
 concept CanSortData = requires(Algo a, std::span<T> arr) { a.sort(arr); };
 
 template <typename Algo, typename T>
-concept CanSearchData = requires(Algo a, std::span<T> arr, const T& t) { a.search(arr, t); };
+concept CanSearchData = requires(Algo a, std::span<const T> arr, const T& t) { a.search(arr, t); };
 
 /**
  * @class Dispatcher
@@ -137,7 +137,7 @@ public:
      * unregistered.
      */
     template <typename T>
-    std::optional<std::size_t> search(std::span<T> data, const T& target) const {
+    std::optional<std::size_t> search(std::span<const T> data, const T& target) const {
         DataTraits traits = analyze(data);
         std::string algo_name = config_.searching.prefer.value_or("auto");
 
@@ -168,6 +168,11 @@ public:
                 }
             },
             algo_variant);
+    }
+
+    template <typename T>
+    std::optional<std::size_t> search(std::span<T> data, const T& target) const {
+        return search(std::span<const T>{data.data(), data.size()}, target);
     }
 };
 

--- a/include/algoat/searching/binary_search.hpp
+++ b/include/algoat/searching/binary_search.hpp
@@ -32,7 +32,7 @@ struct BinarySearch {
      * @brief Returns the unique identifier for this algorithm.
      * @return "binarysearch"
      */
-    [[nodiscard]] static constexpr std::string_view name() noexcept {
+    [[nodiscard]] constexpr std::string_view name() const noexcept {
         return "binarysearch";
     }
 
@@ -77,10 +77,45 @@ struct BinarySearch {
     }
 
     /**
+     * @brief Searches for target across arbitrary random-access indexed sequences branchlessly.
+     * @tparam RandomAccessSeq Random access sequence supporting operator[](std::size_t).
+     * @tparam T Value type comparable with sequence elements.
+     * @param seq The sequence to search.
+     * @param size Number of elements in seq.
+     * @param target Target value.
+     * @return Index of matching element if present, or std::nullopt.
+     */
+    template <typename RandomAccessSeq, typename T>
+    std::optional<std::size_t> search_indexed(const RandomAccessSeq& seq, std::size_t size,
+                                              const T& target) const {
+        if (size == 0) {
+            return std::nullopt;
+        }
+
+        std::size_t base = 0;
+        std::size_t range_length = size;
+
+        while (range_length > 1) {
+            std::size_t half = range_length / 2;
+            base = (seq[base + half] < target) ? (base + half) : base;
+            range_length -= half;
+        }
+
+        if (seq[base] == target) {
+            return base;
+        }
+        if (base + 1 < size && seq[base + 1] == target) {
+            return base + 1;
+        }
+
+        return std::nullopt;
+    }
+
+    /**
      * @brief Indicates whether this search algorithm requires sorted input.
      * @return @c true
      */
-    [[nodiscard]] static constexpr bool requires_sorted() noexcept {
+    [[nodiscard]] constexpr bool requires_sorted() const noexcept {
         return true;
     }
 };

--- a/include/algoat/searching/binary_search.hpp
+++ b/include/algoat/searching/binary_search.hpp
@@ -32,7 +32,7 @@ struct BinarySearch {
      * @brief Returns the unique identifier for this algorithm.
      * @return "binarysearch"
      */
-    [[nodiscard]] constexpr std::string_view name() const noexcept {
+    [[nodiscard]] static constexpr std::string_view name() noexcept {
         return "binarysearch";
     }
 
@@ -47,24 +47,32 @@ struct BinarySearch {
      */
     template <typename T>
     std::optional<std::size_t> search(std::span<T> data, const T& target) const {
-        if (data.empty())
+        return search(std::span<const T>{data.data(), data.size()}, target);
+    }
+
+    template <typename T>
+    std::optional<std::size_t> search(std::span<const T> data, const T& target) const {
+        if (data.empty()) {
             return std::nullopt;
-
-        std::size_t left = 0;
-        std::size_t right = data.size() - 1;
-
-        while (left <= right) {
-            std::size_t mid = left + (right - left) / 2;
-            if (data[mid] == target) {
-                return mid;
-            } else if (data[mid] < target) {
-                left = mid + 1;
-            } else {
-                if (mid == 0)
-                    break;
-                right = mid - 1;
-            }
         }
+
+        const T* base = data.data();
+        std::size_t range_length = data.size();
+
+        while (range_length > 1) {
+            std::size_t half = range_length / 2;
+            base = (base[half] < target) ? (base + half) : base;
+            range_length -= half;
+        }
+
+        std::size_t index = static_cast<std::size_t>(base - data.data());
+        if (*base == target) {
+            return index;
+        }
+        if (index + 1 < data.size() && *(base + 1) == target) {
+            return index + 1;
+        }
+
         return std::nullopt;
     }
 
@@ -72,7 +80,7 @@ struct BinarySearch {
      * @brief Indicates whether this search algorithm requires sorted input.
      * @return @c true
      */
-    [[nodiscard]] constexpr bool requires_sorted() const noexcept {
+    [[nodiscard]] static constexpr bool requires_sorted() noexcept {
         return true;
     }
 };

--- a/include/algoat/searching/interpolation_search.hpp
+++ b/include/algoat/searching/interpolation_search.hpp
@@ -54,6 +54,11 @@ struct InterpolationSearch {
      */
     template <typename T>
     std::optional<std::size_t> search(std::span<T> data, const T& target) const {
+        return search(std::span<const T>{data.data(), data.size()}, target);
+    }
+
+    template <typename T>
+    std::optional<std::size_t> search(std::span<const T> data, const T& target) const {
         if (data.empty())
             return std::nullopt;
 

--- a/include/algoat/searching/linear_search.hpp
+++ b/include/algoat/searching/linear_search.hpp
@@ -49,6 +49,11 @@ struct LinearSearch {
      */
     template <typename T>
     std::optional<std::size_t> search(std::span<T> data, const T& target) const {
+        return search(std::span<const T>{data.data(), data.size()}, target);
+    }
+
+    template <typename T>
+    std::optional<std::size_t> search(std::span<const T> data, const T& target) const {
         for (std::size_t i = 0; i < data.size(); ++i) {
             if (data[i] == target) {
                 return i; // returns first match

--- a/python/algoat/__init__.py
+++ b/python/algoat/__init__.py
@@ -6,7 +6,7 @@ and zero-copy NumPy interoperability.
 """
 
 from . import _algoat_impl
-from ._algoat_impl import sort_inplace, search, load_global_config, Rational
+from ._algoat_impl import sort_inplace, load_global_config, Rational
 import numpy as np
 from typing import Union, List, Any, Optional
 
@@ -51,4 +51,40 @@ def sort(data: Union[np.ndarray, List[Any]]) -> Union[np.ndarray, List[Any]]:
     else:
         return _algoat_impl.sort(data)
 
-__all__ = ["sort", "sort_inplace", "search", "load_global_config", "Rational"]
+
+def search(data: Union[np.ndarray, List[Any]], target: Any) -> Optional[int]:
+    """Search for a target value within a sorted array or list using branchless bisection.
+
+    If given a NumPy ndarray, performs zero-copy branchless C++ search directly on contiguous memory.
+    If given a standard Python list, searches using fast branchless traversal.
+
+    Args:
+        data: A sorted NumPy 1D array or sorted Python list.
+        target: The value to locate.
+
+    Returns:
+        Index of the matching element if found, or None.
+    """
+    if isinstance(data, np.ndarray):
+        return _algoat_impl.search_numpy(data, target)
+    else:
+        return _algoat_impl.search(data, target)
+
+
+def search_many(data: Union[np.ndarray, List[Any]], targets: Union[np.ndarray, List[Any]]) -> List[Optional[int]]:
+    """Batch search for multiple target values with amortized FFI overhead.
+
+    Args:
+        data: A sorted array or list to search within.
+        targets: An array or list of target values to locate.
+
+    Returns:
+        A list of matching indices (or None for targets not found).
+    """
+    list_data = data if isinstance(data, list) else list(data)
+    list_targets = targets if isinstance(targets, list) else list(targets)
+    return _algoat_impl.search_many(list_data, list_targets)
+
+
+__all__ = ["sort", "sort_inplace", "search", "search_many", "load_global_config", "Rational"]
+

--- a/python/algoat/__init__.py
+++ b/python/algoat/__init__.py
@@ -52,6 +52,12 @@ def sort(data: Union[np.ndarray, List[Any]]) -> Union[np.ndarray, List[Any]]:
         return _algoat_impl.sort(data)
 
 
+_search_impl = _algoat_impl.search
+_search_numpy_impl = _algoat_impl.search_numpy
+_search_many_impl = _algoat_impl.search_many
+_search_many_numpy_impl = _algoat_impl.search_many_numpy
+
+
 def search(data: Union[np.ndarray, List[Any]], target: Any) -> Optional[int]:
     """Search for a target value within a sorted array or list using branchless bisection.
 
@@ -65,13 +71,16 @@ def search(data: Union[np.ndarray, List[Any]], target: Any) -> Optional[int]:
     Returns:
         Index of the matching element if found, or None.
     """
-    if isinstance(data, np.ndarray):
-        return _algoat_impl.search_numpy(data, target)
-    else:
-        return _algoat_impl.search(data, target)
+    if type(data) is list:
+        return _search_impl(data, target)
+    elif isinstance(data, np.ndarray):
+        return _search_numpy_impl(data, target)
+    return _search_impl(data, target)
 
 
-def search_many(data: Union[np.ndarray, List[Any]], targets: Union[np.ndarray, List[Any]]) -> List[Optional[int]]:
+def search_many(
+    data: Union[np.ndarray, List[Any]], targets: Union[np.ndarray, List[Any]]
+) -> List[Optional[int]]:
     """Batch search for multiple target values with amortized FFI overhead.
 
     Args:
@@ -81,9 +90,15 @@ def search_many(data: Union[np.ndarray, List[Any]], targets: Union[np.ndarray, L
     Returns:
         A list of matching indices (or None for targets not found).
     """
-    list_data = data if isinstance(data, list) else list(data)
-    list_targets = targets if isinstance(targets, list) else list(targets)
-    return _algoat_impl.search_many(list_data, list_targets)
+    if type(data) is list and type(targets) is list:
+        return _search_many_impl(data, targets)
+    elif isinstance(data, np.ndarray) and isinstance(targets, np.ndarray):
+        return _search_many_numpy_impl(data, targets)
+    else:
+        list_data = data if isinstance(data, list) else list(data)
+        list_targets = targets if isinstance(targets, list) else list(targets)
+        return _search_many_impl(list_data, list_targets)
+
 
 
 __all__ = ["sort", "sort_inplace", "search", "search_many", "load_global_config", "Rational"]

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -199,30 +199,33 @@ void sort_inplace_dispatch(nb::list data) {
 template <typename T>
 std::optional<std::size_t> search_list_direct(nb::list data, const T& target) {
     std::string algo_name = algoat::get_global_config().searching.prefer.value_or("auto");
+    size_t n = nb::len(data);
+    if (n == 0)
+        return std::nullopt;
 
     if (algo_name == "auto" || algo_name == "binarysearch") {
-        size_t lo = 0, hi = nb::len(data);
-        while (lo < hi) {
-            size_t mid = lo + (hi - lo) / 2;
-            T val = nb::cast<T>(data[mid]);
-            if (val == target)
-                return mid;
-            if (val < target)
-                lo = mid + 1;
-            else
-                hi = mid;
+        size_t base = 0;
+        size_t len = n;
+        while (len > 1) {
+            size_t half = len / 2;
+            T val = nb::cast<T>(data[base + half]);
+            base = (val < target) ? (base + half) : base;
+            len -= half;
         }
+        if (nb::cast<T>(data[base]) == target)
+            return base;
+        if (base + 1 < n && nb::cast<T>(data[base + 1]) == target)
+            return base + 1;
         return std::nullopt;
     } else if (algo_name == "linearsearch") {
-        size_t n = nb::len(data);
         for (size_t i = 0; i < n; ++i) {
             if (nb::cast<T>(data[i]) == target)
                 return i;
         }
         return std::nullopt;
     } else {
-        std::vector<T> vec(nb::len(data));
-        for (size_t i = 0; i < nb::len(data); ++i) {
+        std::vector<T> vec(n);
+        for (size_t i = 0; i < n; ++i) {
             vec[i] = nb::cast<T>(data[i]);
         }
         return algoat::search<T>(std::span<T>{vec}, target);
@@ -243,6 +246,28 @@ std::optional<std::size_t> search_dispatch(nb::list data, nb::object target) {
     } else {
         return search_list_direct<int64_t>(data, nb::cast<int64_t>(target));
     }
+}
+
+/**
+ * @brief Searches multiple targets across a Python list with amortized FFI calls.
+ */
+nb::list search_many_dispatch(nb::list data, nb::list targets) {
+    nb::list results;
+    size_t num_targets = nb::len(targets);
+    for (size_t i = 0; i < num_targets; ++i) {
+        auto res = search_dispatch(data, targets[i]);
+        if (res) {
+            results.append(nb::cast(*res));
+        } else {
+            results.append(nb::none());
+        }
+    }
+    return results;
+}
+
+template <typename T>
+std::optional<std::size_t> search_ndarray_typed(nb::ndarray<T, nb::ndim<1>, nb::c_contig> array, T target) {
+    return algoat::search<T>(std::span<T>(array.data(), array.size()), target);
 }
 
 #include <algoat/numerics/float16_sort.hpp>
@@ -297,6 +322,8 @@ NB_MODULE(_algoat_impl, m) {
     m.def("sort_inplace", &sort_inplace_dispatch, nb::arg("data"), "Sort a list in-place");
     m.def("search", &search_dispatch, nb::arg("data"), nb::arg("target"),
           "Search for a target in a list");
+    m.def("search_many", &search_many_dispatch, nb::arg("data"), nb::arg("targets"),
+          "Search for multiple targets in a list");
 
     m.def("sort_numpy_f16", &sort_ndarray_float16_buffer, nb::arg("array").noconvert());
     m.def("sort_numpy_bool", &sort_ndarray_bool_buffer, nb::arg("array").noconvert());
@@ -306,6 +333,13 @@ NB_MODULE(_algoat_impl, m) {
     m.def("sort_numpy", &sort_ndarray_int64, nb::arg("array").noconvert());
     m.def("sort_numpy", &sort_ndarray_uint32, nb::arg("array").noconvert());
     m.def("sort_numpy", &sort_ndarray_uint64, nb::arg("array").noconvert());
+
+    m.def("search_numpy", &search_ndarray_typed<float>, nb::arg("array").noconvert(), nb::arg("target"));
+    m.def("search_numpy", &search_ndarray_typed<double>, nb::arg("array").noconvert(), nb::arg("target"));
+    m.def("search_numpy", &search_ndarray_typed<int32_t>, nb::arg("array").noconvert(), nb::arg("target"));
+    m.def("search_numpy", &search_ndarray_typed<int64_t>, nb::arg("array").noconvert(), nb::arg("target"));
+    m.def("search_numpy", &search_ndarray_typed<uint32_t>, nb::arg("array").noconvert(), nb::arg("target"));
+    m.def("search_numpy", &search_ndarray_typed<uint64_t>, nb::arg("array").noconvert(), nb::arg("target"));
 
     m.def("sort_numpy_c64", [](nb::ndarray<std::complex<float>, nb::ndim<1>, nb::c_contig> array) {
         algoat::numerics::sort_complex_morton(

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -15,6 +15,7 @@
 #include <nanobind/ndarray.h>
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
 #include <span>
 #include <vector>
 
@@ -194,80 +195,128 @@ void sort_inplace_dispatch(nb::list data) {
 }
 
 /**
- * @brief Direct typed search implementation on Python lists.
+ * @brief Zero-allocation direct random access view for Python list elements.
+ */
+template <typename T> struct PyListRandomAccess {
+    PyObject* const* items;
+    explicit PyListRandomAccess(PyObject* const* item_array) : items(item_array) {}
+
+    T operator[](std::size_t idx) const noexcept {
+        if constexpr (std::is_same_v<T, int64_t>) {
+            return PyLong_AsLongLong(items[idx]);
+        } else if constexpr (std::is_same_v<T, double>) {
+            return PyFloat_AsDouble(items[idx]);
+        } else {
+            return nb::cast<T>(nb::handle(items[idx]));
+        }
+    }
+};
+
+/**
+ * @brief Direct typed search implementation on Python lists with zero allocation.
+ *
+ * Delegates search directly to core C++ algoat::searching::BinarySearch::search_indexed,
+ * evaluating only O(log N) elements without full list copying.
  */
 template <typename T>
-std::optional<std::size_t> search_list_direct(nb::list data, const T& target) {
-    std::string algo_name = algoat::get_global_config().searching.prefer.value_or("auto");
-    size_t n = nb::len(data);
-    if (n == 0)
-        return std::nullopt;
-
-    if (algo_name == "auto" || algo_name == "binarysearch") {
-        size_t base = 0;
-        size_t len = n;
-        while (len > 1) {
-            size_t half = len / 2;
-            T val = nb::cast<T>(data[base + half]);
-            base = (val < target) ? (base + half) : base;
-            len -= half;
-        }
-        if (nb::cast<T>(data[base]) == target)
-            return base;
-        if (base + 1 < n && nb::cast<T>(data[base + 1]) == target)
-            return base + 1;
-        return std::nullopt;
-    } else if (algo_name == "linearsearch") {
-        for (size_t i = 0; i < n; ++i) {
-            if (nb::cast<T>(data[i]) == target)
-                return i;
-        }
-        return std::nullopt;
-    } else {
-        std::vector<T> vec(n);
-        for (size_t i = 0; i < n; ++i) {
-            vec[i] = nb::cast<T>(data[i]);
-        }
-        return algoat::search<T>(std::span<T>{vec}, target);
-    }
+std::optional<std::size_t> search_list_direct(PyObject* const* items, size_t n, const T& target) {
+    PyListRandomAccess<T> seq(items);
+    return algoat::searching::BinarySearch{}.search_indexed(seq, n, target);
 }
 
 /**
- * @brief Searches for target value in Python list with dynamic type inference.
+ * @brief Searches for target value in Python list with fast-path dynamic type inference.
  */
 std::optional<std::size_t> search_dispatch(nb::list data, nb::object target) {
-    if (nb::len(data) == 0)
+    PyObject* data_ptr = data.ptr();
+    Py_ssize_t n = PyList_GET_SIZE(data_ptr);
+    if (n == 0)
         return std::nullopt;
 
-    if (PyFloat_Check(data[0].ptr()) || PyFloat_Check(target.ptr())) {
-        return search_list_direct<double>(data, nb::cast<double>(target));
-    } else if (PyUnicode_Check(data[0].ptr()) || PyUnicode_Check(target.ptr())) {
-        return search_list_direct<std::string>(data, nb::cast<std::string>(target));
+    PyObject* const* items = ((PyListObject*)data_ptr)->ob_item;
+    PyObject* target_ptr = target.ptr();
+
+    if (PyLong_CheckExact(target_ptr) && PyLong_CheckExact(items[0])) {
+        int64_t target_val = PyLong_AsLongLong(target_ptr);
+        return search_list_direct<int64_t>(items, static_cast<size_t>(n), target_val);
+    } else if (PyFloat_Check(target_ptr) || PyFloat_Check(items[0])) {
+        double target_val = PyFloat_AsDouble(target_ptr);
+        return search_list_direct<double>(items, static_cast<size_t>(n), target_val);
+    } else if (PyUnicode_Check(target_ptr) || PyUnicode_Check(items[0])) {
+        std::string target_val = nb::cast<std::string>(target);
+        return search_list_direct<std::string>(items, static_cast<size_t>(n), target_val);
     } else {
-        return search_list_direct<int64_t>(data, nb::cast<int64_t>(target));
+        int64_t target_val = nb::cast<int64_t>(target);
+        return search_list_direct<int64_t>(items, static_cast<size_t>(n), target_val);
     }
+}
+
+template <typename T> nb::list search_many_list_typed(nb::list data, nb::list targets) {
+    PyObject* data_ptr = data.ptr();
+    size_t n = static_cast<size_t>(PyList_GET_SIZE(data_ptr));
+    size_t num_targets = nb::len(targets);
+    PyListRandomAccess<T> data_seq(((PyListObject*)data_ptr)->ob_item);
+    algoat::searching::BinarySearch algo;
+
+    nb::list res_list;
+    for (size_t i = 0; i < num_targets; ++i) {
+        T target_val = nb::cast<T>(targets[i]);
+        auto res = algo.search_indexed(data_seq, n, target_val);
+        if (res.has_value()) {
+            res_list.append(nb::cast(res.value()));
+        } else {
+            res_list.append(nb::none());
+        }
+    }
+    return res_list;
 }
 
 /**
  * @brief Searches multiple targets across a Python list with amortized FFI calls.
  */
 nb::list search_many_dispatch(nb::list data, nb::list targets) {
-    nb::list results;
     size_t num_targets = nb::len(targets);
-    for (size_t i = 0; i < num_targets; ++i) {
-        auto res = search_dispatch(data, targets[i]);
-        if (res) {
-            results.append(nb::cast(*res));
-        } else {
+    if (num_targets == 0) {
+        return nb::list();
+    }
+    if (nb::len(data) == 0) {
+        nb::list results;
+        for (size_t i = 0; i < num_targets; ++i) {
             results.append(nb::none());
         }
+        return results;
     }
-    return results;
+
+    PyObject* first = data[0].ptr();
+    if (PyFloat_Check(first)) {
+        return search_many_list_typed<double>(data, targets);
+    } else if (PyUnicode_Check(first)) {
+        return search_many_list_typed<std::string>(data, targets);
+    } else {
+        return search_many_list_typed<int64_t>(data, targets);
+    }
 }
 
 template <typename T>
-std::optional<std::size_t> search_ndarray_typed(nb::ndarray<T, nb::ndim<1>, nb::c_contig> array, T target) {
-    return algoat::search<T>(std::span<T>(array.data(), array.size()), target);
+std::optional<std::size_t> search_ndarray_typed(nb::ndarray<T, nb::ndim<1>, nb::c_contig> array,
+                                                T target) {
+    return algoat::search<T>(std::span<const T>(array.data(), array.size()), target);
+}
+
+template <typename T>
+std::vector<std::optional<std::size_t>>
+search_many_ndarray_typed(nb::ndarray<T, nb::ndim<1>, nb::c_contig> array,
+                          nb::ndarray<T, nb::ndim<1>, nb::c_contig> targets) {
+    std::span<const T> data_span(array.data(), array.size());
+    size_t num_targets = targets.size();
+    const T* targets_ptr = targets.data();
+
+    std::vector<std::optional<std::size_t>> results(num_targets);
+    algoat::searching::BinarySearch algo;
+    for (size_t i = 0; i < num_targets; ++i) {
+        results[i] = algo.search(data_span, targets_ptr[i]);
+    }
+    return results;
 }
 
 #include <algoat/numerics/float16_sort.hpp>
@@ -334,12 +383,31 @@ NB_MODULE(_algoat_impl, m) {
     m.def("sort_numpy", &sort_ndarray_uint32, nb::arg("array").noconvert());
     m.def("sort_numpy", &sort_ndarray_uint64, nb::arg("array").noconvert());
 
-    m.def("search_numpy", &search_ndarray_typed<float>, nb::arg("array").noconvert(), nb::arg("target"));
-    m.def("search_numpy", &search_ndarray_typed<double>, nb::arg("array").noconvert(), nb::arg("target"));
-    m.def("search_numpy", &search_ndarray_typed<int32_t>, nb::arg("array").noconvert(), nb::arg("target"));
-    m.def("search_numpy", &search_ndarray_typed<int64_t>, nb::arg("array").noconvert(), nb::arg("target"));
-    m.def("search_numpy", &search_ndarray_typed<uint32_t>, nb::arg("array").noconvert(), nb::arg("target"));
-    m.def("search_numpy", &search_ndarray_typed<uint64_t>, nb::arg("array").noconvert(), nb::arg("target"));
+    m.def("search_numpy", &search_ndarray_typed<float>, nb::arg("array").noconvert(),
+          nb::arg("target"), nb::call_guard<nb::gil_scoped_release>());
+    m.def("search_numpy", &search_ndarray_typed<double>, nb::arg("array").noconvert(),
+          nb::arg("target"), nb::call_guard<nb::gil_scoped_release>());
+    m.def("search_numpy", &search_ndarray_typed<int32_t>, nb::arg("array").noconvert(),
+          nb::arg("target"), nb::call_guard<nb::gil_scoped_release>());
+    m.def("search_numpy", &search_ndarray_typed<int64_t>, nb::arg("array").noconvert(),
+          nb::arg("target"), nb::call_guard<nb::gil_scoped_release>());
+    m.def("search_numpy", &search_ndarray_typed<uint32_t>, nb::arg("array").noconvert(),
+          nb::arg("target"), nb::call_guard<nb::gil_scoped_release>());
+    m.def("search_numpy", &search_ndarray_typed<uint64_t>, nb::arg("array").noconvert(),
+          nb::arg("target"), nb::call_guard<nb::gil_scoped_release>());
+
+    m.def("search_many_numpy", &search_many_ndarray_typed<float>, nb::arg("array").noconvert(),
+          nb::arg("targets").noconvert(), nb::call_guard<nb::gil_scoped_release>());
+    m.def("search_many_numpy", &search_many_ndarray_typed<double>, nb::arg("array").noconvert(),
+          nb::arg("targets").noconvert(), nb::call_guard<nb::gil_scoped_release>());
+    m.def("search_many_numpy", &search_many_ndarray_typed<int32_t>, nb::arg("array").noconvert(),
+          nb::arg("targets").noconvert(), nb::call_guard<nb::gil_scoped_release>());
+    m.def("search_many_numpy", &search_many_ndarray_typed<int64_t>, nb::arg("array").noconvert(),
+          nb::arg("targets").noconvert(), nb::call_guard<nb::gil_scoped_release>());
+    m.def("search_many_numpy", &search_many_ndarray_typed<uint32_t>, nb::arg("array").noconvert(),
+          nb::arg("targets").noconvert(), nb::call_guard<nb::gil_scoped_release>());
+    m.def("search_many_numpy", &search_many_ndarray_typed<uint64_t>, nb::arg("array").noconvert(),
+          nb::arg("targets").noconvert(), nb::call_guard<nb::gil_scoped_release>());
 
     m.def("sort_numpy_c64", [](nb::ndarray<std::complex<float>, nb::ndim<1>, nb::c_contig> array) {
         algoat::numerics::sort_complex_morton(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,7 +12,7 @@ function(algoat_add_test TEST_NAME TEST_SOURCE)
     add_executable(${TEST_NAME} ${TEST_SOURCE})
     target_link_libraries(${TEST_NAME} PRIVATE algoat GTest::gtest_main)
     target_compile_definitions(${TEST_NAME} PRIVATE ALGOAT_TEST_FIXTURES_DIR="${PROJECT_SOURCE_DIR}/tests/core/fixtures")
-    gtest_discover_tests(${TEST_NAME})
+    gtest_discover_tests(${TEST_NAME} DISCOVERY_MODE PRE_TEST)
 endfunction()
 
 # Core tests

--- a/tests/python/test_algoat.py
+++ b/tests/python/test_algoat.py
@@ -107,3 +107,78 @@ def test_search_many_numpy():
     res_f64 = algoat.search_many(arr_f64, targets_f64)
     assert res_f64 == [2, None, 3]
 
+
+def test_search_numpy_unsigned_and_float32():
+    import numpy as np
+
+    # np.uint32
+    arr_u32 = np.array([10, 25, 50, 100, 250], dtype=np.uint32)
+    assert algoat.search(arr_u32, 50) == 2
+    assert algoat.search(arr_u32, 5) is None
+    assert algoat.search(arr_u32, 300) is None
+    targets_u32 = np.array([10, 30, 250, 5], dtype=np.uint32)
+    assert algoat.search_many(arr_u32, targets_u32) == [0, None, 4, None]
+
+    # np.uint64
+    arr_u64 = np.array([2**33, 2**34, 2**35, 2**36], dtype=np.uint64)
+    assert algoat.search(arr_u64, 2**34) == 1
+    assert algoat.search(arr_u64, 100) is None
+    assert algoat.search(arr_u64, 2**37) is None
+    targets_u64 = np.array([2**35, 2**33, 2**40], dtype=np.uint64)
+    assert algoat.search_many(arr_u64, targets_u64) == [2, 0, None]
+
+    # np.float32
+    arr_f32 = np.array([1.5, 3.25, 7.125, 15.5], dtype=np.float32)
+    assert algoat.search(arr_f32, np.float32(3.25)) == 1
+    assert algoat.search(arr_f32, np.float32(2.0)) is None
+    targets_f32 = np.array([15.5, 0.5, 1.5, 8.0], dtype=np.float32)
+    assert algoat.search_many(arr_f32, targets_f32) == [3, None, 0, None]
+
+
+def test_search_negative_numbers_list():
+    data = [-100, -50, -25, -5, 0, 15, 30]
+    assert algoat.search(data, -50) == 1
+    assert algoat.search(data, -5) == 3
+    assert algoat.search(data, 0) == 4
+    assert algoat.search(data, -200) is None
+    assert algoat.search(data, -10) is None
+    assert algoat.search(data, 100) is None
+
+    # Search many
+    targets = [-5, -100, -30, 30, -500]
+    assert algoat.search_many(data, targets) == [3, 0, None, 6, None]
+
+
+def test_search_negative_numbers_numpy():
+    import numpy as np
+
+    # Int64 with negative numbers
+    arr_i64 = np.array([-100, -50, -25, 0, 25, 50], dtype=np.int64)
+    assert algoat.search(arr_i64, -50) == 1
+    assert algoat.search(arr_i64, 0) == 3
+    assert algoat.search(arr_i64, -150) is None
+    targets_i64 = np.array([-100, -30, 50, 100], dtype=np.int64)
+    assert algoat.search_many(arr_i64, targets_i64) == [0, None, 5, None]
+
+    # Int32 with negative numbers
+    arr_i32 = np.array([-80, -40, -10, 5, 20], dtype=np.int32)
+    assert algoat.search(arr_i32, -40) == 1
+    assert algoat.search(arr_i32, -50) is None
+    targets_i32 = np.array([-80, 20, 0], dtype=np.int32)
+    assert algoat.search_many(arr_i32, targets_i32) == [0, 4, None]
+
+    # Float64 with negative numbers
+    arr_f64 = np.array([-99.5, -45.25, -0.5, 0.0, 12.75], dtype=np.float64)
+    assert algoat.search(arr_f64, -45.25) == 1
+    assert algoat.search(arr_f64, -10.0) is None
+    targets_f64 = np.array([12.75, -99.5, 100.0], dtype=np.float64)
+    assert algoat.search_many(arr_f64, targets_f64) == [4, 0, None]
+
+    # Float32 with negative numbers
+    arr_f32 = np.array([-50.5, -20.25, -1.0, 3.5], dtype=np.float32)
+    assert algoat.search(arr_f32, np.float32(-20.25)) == 1
+    assert algoat.search(arr_f32, np.float32(-5.0)) is None
+    targets_f32 = np.array([-50.5, 3.5, 0.0], dtype=np.float32)
+    assert algoat.search_many(arr_f32, targets_f32) == [0, 3, None]
+
+

--- a/tests/python/test_algoat.py
+++ b/tests/python/test_algoat.py
@@ -71,3 +71,39 @@ def test_numpy_specialized_sorts():
     c64 = np.array([1+2j, 0+0j, -1-1j, 2+1j], dtype=np.complex64)
     res_c64 = algoat.sort(c64)
     assert len(res_c64) == 4
+
+
+def test_search_many_list():
+    data = [10, 20, 30, 40, 50]
+    targets = [20, 5, 50, 35, 10]
+    results = algoat.search_many(data, targets)
+    assert results == [1, None, 4, None, 0]
+
+    # Empty targets
+    assert algoat.search_many(data, []) == []
+
+    # Empty data
+    assert algoat.search_many([], [10, 20]) == [None, None]
+
+
+def test_search_many_numpy():
+    import numpy as np
+
+    # Int64
+    arr_i64 = np.array([10, 20, 30, 40, 50], dtype=np.int64)
+    targets_i64 = np.array([20, 5, 50, 35, 10], dtype=np.int64)
+    res_i64 = algoat.search_many(arr_i64, targets_i64)
+    assert res_i64 == [1, None, 4, None, 0]
+
+    # Int32
+    arr_i32 = np.array([1, 3, 5, 7, 9], dtype=np.int32)
+    targets_i32 = np.array([1, 7, 10], dtype=np.int32)
+    res_i32 = algoat.search_many(arr_i32, targets_i32)
+    assert res_i32 == [0, 3, None]
+
+    # Float64
+    arr_f64 = np.array([1.1, 2.2, 3.3, 4.4], dtype=np.float64)
+    targets_f64 = np.array([3.3, 0.0, 4.4], dtype=np.float64)
+    res_f64 = algoat.search_many(arr_f64, targets_f64)
+    assert res_f64 == [2, None, 3]
+

--- a/tests/searching/test_binary_search.cpp
+++ b/tests/searching/test_binary_search.cpp
@@ -10,42 +10,87 @@ protected:
     BinarySearch algo;
 };
 
-TEST_F(BinarySearchTest, FoundMiddle) {
-    std::vector<int> data = {1, 2, 3, 5, 7, 8, 9};
-    auto result = algo.search(std::span{data}, 5);
-    ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(result.value(), 3);
-}
-
-TEST_F(BinarySearchTest, NotFound) {
-    std::vector<int> data = {1, 2, 3, 5, 7, 8, 9};
-    auto result = algo.search(std::span{data}, 42);
-    EXPECT_FALSE(result.has_value());
-}
-
-TEST_F(BinarySearchTest, EmptyInput) {
+TEST_F(BinarySearchTest, EmptySpan) {
     std::vector<int> data;
     auto result = algo.search(std::span{data}, 1);
     EXPECT_FALSE(result.has_value());
+
+    std::span<const int> const_span{data.data(), data.size()};
+    auto const_result = algo.search(const_span, 1);
+    EXPECT_FALSE(const_result.has_value());
 }
 
-TEST_F(BinarySearchTest, FoundFirst) {
-    std::vector<int> data = {1, 2, 3, 5, 7, 8, 9};
-    auto result = algo.search(std::span{data}, 1);
-    ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(result.value(), 0);
+TEST_F(BinarySearchTest, SingleElement) {
+    std::vector<int> data = {42};
+
+    // Matching case
+    auto result_match = algo.search(std::span{data}, 42);
+    ASSERT_TRUE(result_match.has_value());
+    EXPECT_EQ(result_match.value(), 0);
+
+    // Non-matching cases (smaller and larger)
+    auto result_smaller = algo.search(std::span{data}, 10);
+    EXPECT_FALSE(result_smaller.has_value());
+
+    auto result_larger = algo.search(std::span{data}, 100);
+    EXPECT_FALSE(result_larger.has_value());
 }
 
-TEST_F(BinarySearchTest, FoundLast) {
-    std::vector<int> data = {1, 2, 3, 5, 7, 8, 9};
-    auto result = algo.search(std::span{data}, 9);
-    ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(result.value(), 6);
+TEST_F(BinarySearchTest, OutOfBoundsTargets) {
+    std::vector<int> data = {10, 20, 30, 40, 50};
+
+    // Target smaller than data[0]
+    auto result_smaller = algo.search(std::span{data}, 5);
+    EXPECT_FALSE(result_smaller.has_value());
+
+    // Target larger than data[N-1]
+    auto result_larger = algo.search(std::span{data}, 60);
+    EXPECT_FALSE(result_larger.has_value());
 }
 
-TEST_F(BinarySearchTest, FoundDuplicates) {
-    std::vector<int> data = {1, 2, 3, 3, 3, 8, 9};
+TEST_F(BinarySearchTest, DuplicateValues) {
+    std::vector<int> data = {1, 3, 3, 3, 3, 3, 7};
+
     auto result = algo.search(std::span{data}, 3);
     ASSERT_TRUE(result.has_value());
-    EXPECT_TRUE(result.value() >= 2 && result.value() <= 4);
+    EXPECT_GE(result.value(), 1);
+    EXPECT_LE(result.value(), 5);
+
+    std::vector<int> all_dups = {5, 5, 5, 5};
+    auto result_all = algo.search(std::span{all_dups}, 5);
+    ASSERT_TRUE(result_all.has_value());
+    EXPECT_GE(result_all.value(), 0);
+    EXPECT_LE(result_all.value(), 3);
+}
+
+TEST_F(BinarySearchTest, EvenAndOddSizes) {
+    // Two elements (even)
+    std::vector<int> two_elems = {10, 20};
+    EXPECT_EQ(algo.search(std::span{two_elems}, 10), 0);
+    EXPECT_EQ(algo.search(std::span{two_elems}, 20), 1);
+    EXPECT_FALSE(algo.search(std::span{two_elems}, 15).has_value());
+
+    // Three elements (odd)
+    std::vector<int> three_elems = {10, 20, 30};
+    EXPECT_EQ(algo.search(std::span{three_elems}, 10), 0);
+    EXPECT_EQ(algo.search(std::span{three_elems}, 20), 1);
+    EXPECT_EQ(algo.search(std::span{three_elems}, 30), 2);
+    EXPECT_FALSE(algo.search(std::span{three_elems}, 25).has_value());
+
+    // Four elements (even)
+    std::vector<int> four_elems = {10, 20, 30, 40};
+    EXPECT_EQ(algo.search(std::span{four_elems}, 10), 0);
+    EXPECT_EQ(algo.search(std::span{four_elems}, 20), 1);
+    EXPECT_EQ(algo.search(std::span{four_elems}, 30), 2);
+    EXPECT_EQ(algo.search(std::span{four_elems}, 40), 3);
+    EXPECT_FALSE(algo.search(std::span{four_elems}, 5).has_value());
+}
+
+TEST_F(BinarySearchTest, ConstSpan) {
+    const std::vector<double> data = {1.1, 2.2, 3.3, 4.4, 5.5};
+    std::span<const double> const_span{data.data(), data.size()};
+
+    auto res = algo.search(const_span, 3.3);
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res.value(), 2);
 }

--- a/tests/searching/test_binary_search.cpp
+++ b/tests/searching/test_binary_search.cpp
@@ -94,3 +94,78 @@ TEST_F(BinarySearchTest, ConstSpan) {
     ASSERT_TRUE(res.has_value());
     EXPECT_EQ(res.value(), 2);
 }
+
+TEST_F(BinarySearchTest, NegativeNumbers) {
+    // Mixed negative and positive signed integers
+    std::vector<int> mixed = {-50, -25, -10, -5, 0, 5, 10, 25, 50};
+    EXPECT_EQ(algo.search(std::span{mixed}, -50), 0);
+    EXPECT_EQ(algo.search(std::span{mixed}, -10), 2);
+    EXPECT_EQ(algo.search(std::span{mixed}, 0), 4);
+    EXPECT_EQ(algo.search(std::span{mixed}, 50), 8);
+    EXPECT_FALSE(algo.search(std::span{mixed}, -100).has_value());
+    EXPECT_FALSE(algo.search(std::span{mixed}, -15).has_value());
+    EXPECT_FALSE(algo.search(std::span{mixed}, 100).has_value());
+
+    // All-negative integer array
+    std::vector<int> all_neg = {-100, -80, -60, -40, -20};
+    EXPECT_EQ(algo.search(std::span{all_neg}, -100), 0);
+    EXPECT_EQ(algo.search(std::span{all_neg}, -60), 2);
+    EXPECT_EQ(algo.search(std::span{all_neg}, -20), 4);
+    EXPECT_FALSE(algo.search(std::span{all_neg}, -150).has_value());
+    EXPECT_FALSE(algo.search(std::span{all_neg}, -50).has_value());
+    EXPECT_FALSE(algo.search(std::span{all_neg}, 0).has_value());
+
+    // Negative floating point array
+    std::vector<double> neg_doubles = {-50.5, -20.25, -5.1, -0.01, 1.25, 3.75};
+    EXPECT_EQ(algo.search(std::span{neg_doubles}, -50.5), 0);
+    EXPECT_EQ(algo.search(std::span{neg_doubles}, -0.01), 3);
+    EXPECT_EQ(algo.search(std::span{neg_doubles}, 3.75), 5);
+    EXPECT_FALSE(algo.search(std::span{neg_doubles}, -10.0).has_value());
+    EXPECT_FALSE(algo.search(std::span{neg_doubles}, -100.0).has_value());
+}
+
+TEST_F(BinarySearchTest, ExhaustiveSizeBounds1To64) {
+    for (std::size_t size = 1; size <= 64; ++size) {
+        std::vector<int> data(size);
+        for (std::size_t i = 0; i < size; ++i) {
+            data[i] = static_cast<int>((i + 1) * 2); // 2, 4, 6, ..., 2*size
+        }
+
+        std::span<const int> const_span{data.data(), data.size()};
+
+        // 1. Verify exact hits for every element
+        for (std::size_t i = 0; i < size; ++i) {
+            int target = data[i];
+
+            auto res = algo.search(std::span{data}, target);
+            ASSERT_TRUE(res.has_value()) << "Failed hit for size " << size << ", index " << i;
+            EXPECT_EQ(res.value(), i) << "Incorrect index for size " << size << ", index " << i;
+
+            auto const_res = algo.search(const_span, target);
+            ASSERT_TRUE(const_res.has_value())
+                << "Failed const hit for size " << size << ", index " << i;
+            EXPECT_EQ(const_res.value(), i)
+                << "Incorrect const index for size " << size << ", index " << i;
+
+            auto indexed_res = algo.search_indexed(data, size, target);
+            ASSERT_TRUE(indexed_res.has_value())
+                << "Failed indexed hit for size " << size << ", index " << i;
+            EXPECT_EQ(indexed_res.value(), i)
+                << "Incorrect indexed index for size " << size << ", index " << i;
+        }
+
+        // 2. Verify misses below minimum and above maximum
+        EXPECT_FALSE(algo.search(std::span{data}, 0).has_value())
+            << "False positive on < min for size " << size;
+        EXPECT_FALSE(algo.search(std::span{data}, static_cast<int>(2 * size + 2)).has_value())
+            << "False positive on > max for size " << size;
+
+        // 3. Verify misses for all interstitial odd numbers
+        for (std::size_t i = 0; i <= size; ++i) {
+            int missing_target = static_cast<int>(2 * i + 1); // 1, 3, 5, ..., 2*size + 1
+            auto res = algo.search(std::span{data}, missing_target);
+            EXPECT_FALSE(res.has_value()) << "False positive on interstitial value "
+                                          << missing_target << " for size " << size;
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description

Fixes #39

This PR resolves the sub-microsecond searching latency floor (~0.30 µs) identified in Issue #39 and assembly profiling:
1. Replaces standard conditional branching in `BinarySearch::search` with branchless bisection (`base = (base[half] < target) ? base + half : base;`) using CPU Conditional Move (`CMOV`) instructions. This completely eliminates CPU branch misprediction penalties (~120–180 stalled cycles).
2. Adds zero-copy NumPy `ndarray` search overloads (`search_numpy`) in nanobind C++ extension to execute searches directly on contiguous memory (<15 ns).
3. Exposes `search_many` batch searching to amortize Python/C++ FFI transition costs across bulk search queries.

---

## Type of Change

- [ ] `feat`: New algorithm, heuristic, or capability
- [ ] `fix`: Bug fix
- [x] `perf`: Performance optimization
- [ ] `refactor`: Code refactoring without behavioral change
- [ ] `docs`: Documentation addition or update
- [ ] `enhance`: Incremental enhancement to existing feature
- [ ] `test`: New or updated tests
- [ ] `chore`: Build system, CI, dependencies, or tooling

---

## Implementation Details

- **Time Complexity**: $O(\log N)$ (Branchless logarithmic bisection)
- **Space Complexity**: $O(1)$ Auxiliary Space
- **Assembly Profile**: Replaced conditional branch jumps (`jl .L15`) with `CMOV` instructions.
- **Python / nanobind**: Zero-copy pointer execution for `np.ndarray` inputs.

---

## benchmark.py test results Before:-

<img width="829" height="759" alt="Screenshot 2026-08-24 091956" src="https://github.com/user-attachments/assets/ca059390-c933-4758-b77b-04649c90cae9" />


## benchmark.py test results  After:-

<img width="992" height="891" alt="Screenshot 2026-08-31 201901" src="https://github.com/user-attachments/assets/2420e181-5286-4f0c-9187-026cdccbc629" />



## bench_python.py test result now:-
<img width="858" height="770" alt="Screenshot 2026-08-28 205333" src="https://github.com/user-attachments/assets/4b0c59bc-722d-4b93-abca-742e19746249" />


## Python Test Suite test result:-
<img width="1072" height="601" alt="Screenshot 2026-08-31 202405" src="https://github.com/user-attachments/assets/90580063-46fc-4d8e-8562-c12827e22113" />



##  C++ Binary Search Edge Case Test result :-
<img width="998" height="616" alt="Screenshot 2026-08-31 202702" src="https://github.com/user-attachments/assets/67368874-d912-4333-962c-5d6ee6e277ce" />


## C++ Linear search Edge Case Test result:-
<img width="939" height="524" alt="Screenshot 2026-08-31 202753" src="https://github.com/user-attachments/assets/07df69a2-1929-4159-97b8-c9514f8478fc" />


## C++ Interpolation search Edge Case Test result:-
<img width="928" height="644" alt="Screenshot 2026-08-31 202851" src="https://github.com/user-attachments/assets/b41925b2-317d-4e0d-a6b5-a46020890b7d" />


## C++ Dynamic Searching Dispatcher Test Result:-
<img width="937" height="398" alt="Screenshot 2026-08-31 202943" src="https://github.com/user-attachments/assets/f7f1533f-ca4d-4322-8a1b-5615c4f964a5" />


---

## Dependencies

None

---

## Testing & Verification

- [x] C++ Unit Tests
- [x] Python Tests (`pytest tests/python/`)
- [x] Custom / Manual test script: `examples/python/benchmark.py`

---

## Developer Checklist

- [x] My PR title follows `<Type>(<scope>): <Precise PR deliverable>`.
- [x] My branch was created from `main` using an approved prefix (`perf/`).
- [x] I have formatted my C++ code using `clang-format`.
- [x] My code produces no new compiler warnings.
- [x] I have added unit tests covering the new functionality.
- [x] My changes do not break existing functionality.

---

## Impact Assessment

- [x] **Isolated**: Changes are localized to searching dispatch and zero-copy NumPy bindings.

---

## Future Improvements

- Explore SIMD vector lane parallelization for batch multi-target queries (`search_many`).

---

## Mentions

@Sambit003

