### PR TITLE
perf(core): make dispatcher a thread-safe singleton

### DIFF
--- a/include/algoat/algoat.hpp
+++ b/include/algoat/algoat.hpp
@@ -21,26 +21,51 @@
 
 namespace algoat {
 
+namespace detail {
+
+struct GlobalConfigState {
+    core::AlgoConfig config;
+    mutable std::shared_mutex mutex;
+};
+
+inline GlobalConfigState& get_global_config_state() {
+    static GlobalConfigState state;
+    return state;
+}
+
+class GlobalConfigReadGuard {
+    const GlobalConfigState& state_;
+    std::shared_lock<std::shared_mutex> lock_;
+
+public:
+    explicit GlobalConfigReadGuard(const GlobalConfigState& state)
+        : state_(state), lock_(state.mutex) {}
+
+    const core::AlgoConfig* operator->() const {
+        return &state_.config;
+    }
+
+    const core::AlgoConfig& get() const {
+        return state_.config;
+    }
+};
+
+} // namespace detail
 /**
  * @brief Retrieves the thread-safe global configuration instance.
  *
  * This singleton @c AlgoConfig controls default preferences, fallback algorithms,
  * and thresholds used by @c algoat::sort and @c algoat::search.
  *
- * @return Reference to the static global @c core::AlgoConfig.
+ * @return RAII read guard providing read-only access to the global configuration.
  */
-inline core::AlgoConfig& get_global_config() {
-    static core::AlgoConfig config;
-    return config;
-}
 
-inline std::shared_mutex& get_global_config_mutex() {
-    static std::shared_mutex mutex;
-    return mutex;
+inline detail::GlobalConfigReadGuard get_global_config() {
+    return detail::GlobalConfigReadGuard(detail::get_global_config_state());
 }
 
 inline core::Dispatcher& get_dispatcher() {
-    static core::Dispatcher dispatcher(get_global_config());
+    static core::Dispatcher dispatcher(detail::get_global_config_state().config);
     return dispatcher;
 }
 
@@ -54,8 +79,9 @@ inline core::Dispatcher& get_dispatcher() {
 inline void load_global_config(const std::string& filepath) {
     auto config = core::load_config(filepath);
 
-    std::unique_lock lock(get_global_config_mutex());
-    get_global_config() = std::move(config);
+    auto& state = detail::get_global_config_state();
+    std::unique_lock lock(state.mutex);
+    state.config = std::move(config);
 }
 
 /**
@@ -70,7 +96,7 @@ inline void load_global_config(const std::string& filepath) {
  * @param data Contiguous span of elements to sort in-place.
  */
 template <typename T> void sort(std::span<T> data) {
-    std::shared_lock lock(get_global_config_mutex());
+    auto config = get_global_config();
     get_dispatcher().sort(data);
 }
 
@@ -89,7 +115,7 @@ template <typename T> void sort(std::span<T> data) {
  * std::nullopt.
  */
 template <typename T> std::optional<std::size_t> search(std::span<const T> data, const T& target) {
-    std::shared_lock lock(get_global_config_mutex());
+    auto config = get_global_config();
     return get_dispatcher().search(data, target);
 }
 

--- a/include/algoat/algoat.hpp
+++ b/include/algoat/algoat.hpp
@@ -57,7 +57,7 @@ public:
  * This singleton @c AlgoConfig controls default preferences, fallback algorithms,
  * and thresholds used by @c algoat::sort and @c algoat::search.
  *
- * @return RAII read guard providing read-only access to the global configuration.
+ * @return A @c detail::GlobalConfigReadGuard proxy that holds a shared read lock on the global @c core::AlgoConfig for its lifetime.
  */
 
 inline detail::GlobalConfigReadGuard get_global_config() {

--- a/include/algoat/algoat.hpp
+++ b/include/algoat/algoat.hpp
@@ -13,7 +13,9 @@
 #include "algoat/core/dispatcher.hpp"
 
 #include <cstddef>
+#include <mutex>
 #include <optional>
+#include <shared_mutex>
 #include <span>
 #include <string>
 
@@ -32,6 +34,16 @@ inline core::AlgoConfig& get_global_config() {
     return config;
 }
 
+inline std::shared_mutex& get_global_config_mutex() {
+    static std::shared_mutex mutex;
+    return mutex;
+}
+
+inline core::Dispatcher& get_dispatcher() {
+    static core::Dispatcher dispatcher(get_global_config());
+    return dispatcher;
+}
+
 /**
  * @brief Loads algorithm configuration overrides from a JSON file into the global config.
  *
@@ -40,7 +52,10 @@ inline core::AlgoConfig& get_global_config() {
  * @throws std::runtime_error If the file cannot be opened or contains invalid JSON.
  */
 inline void load_global_config(const std::string& filepath) {
-    get_global_config() = core::load_config(filepath);
+    auto config = core::load_config(filepath);
+
+    std::unique_lock lock(get_global_config_mutex());
+    get_global_config() = std::move(config);
 }
 
 /**
@@ -55,8 +70,8 @@ inline void load_global_config(const std::string& filepath) {
  * @param data Contiguous span of elements to sort in-place.
  */
 template <typename T> void sort(std::span<T> data) {
-    core::Dispatcher dispatcher(get_global_config());
-    dispatcher.sort(data);
+    std::shared_lock lock(get_global_config_mutex());
+    get_dispatcher().sort(data);
 }
 
 /**
@@ -74,8 +89,8 @@ template <typename T> void sort(std::span<T> data) {
  * std::nullopt.
  */
 template <typename T> std::optional<std::size_t> search(std::span<const T> data, const T& target) {
-    core::Dispatcher dispatcher(get_global_config());
-    return dispatcher.search(data, target);
+    std::shared_lock lock(get_global_config_mutex());
+    return get_dispatcher().search(data, target);
 }
 
 template <typename T> std::optional<std::size_t> search(std::span<T> data, const T& target) {

--- a/include/algoat/core/dispatcher.hpp
+++ b/include/algoat/core/dispatcher.hpp
@@ -57,7 +57,7 @@ class Dispatcher {
     Registry<sorting::SortVariant> sort_registry_; ///< Registry of available sorting algorithms.
     Registry<searching::SearchVariant>
         search_registry_; ///< Registry of available searching algorithms.
-    AlgoConfig config_;   ///< User-defined configuration preferences.
+    AlgoConfig& config_;   ///< User-defined configuration preferences.
 
 public:
     /**
@@ -65,7 +65,7 @@ public:
      *
      * @param config Configuration options specifying algorithm preferences and fallbacks.
      */
-    explicit Dispatcher(AlgoConfig config);
+    explicit Dispatcher(AlgoConfig& config);
 
     /**
      * @brief Sorts a contiguous span using dynamic heuristic selection.

--- a/include/algoat/core/dispatcher.hpp
+++ b/include/algoat/core/dispatcher.hpp
@@ -57,8 +57,7 @@ class Dispatcher {
     Registry<sorting::SortVariant> sort_registry_; ///< Registry of available sorting algorithms.
     Registry<searching::SearchVariant>
         search_registry_; ///< Registry of available searching algorithms.
-    AlgoConfig& config_;   ///< User-defined configuration preferences.
-
+    AlgoConfig& config_;   ///< Configuration reference; callers must hold the appropriate external lock when accessing it.
 public:
     /**
      * @brief Constructs a Dispatcher with the given configuration, registering default algorithms.

--- a/src/core/dispatcher.cpp
+++ b/src/core/dispatcher.cpp
@@ -30,7 +30,7 @@
 
 namespace algoat::core {
 
-Dispatcher::Dispatcher(AlgoConfig config) : config_(std::move(config)) {
+Dispatcher::Dispatcher(AlgoConfig& config) : config_(config) {
     // Register all supported sorting algorithms into the sorting registry
     // Each algorithm maps to a variant constructor lambda.
     sort_registry_.register_algo("insertionsort",


### PR DESCRIPTION
## Description

Fixes #6

This PR makes the Algoat dispatcher thread-safe by introducing a process-wide singleton dispatcher and synchronized access to the global configuration.

The implementation uses `std::shared_mutex` to allow concurrent read access for sorting and searching operations while ensuring exclusive access when the global configuration is updated.

This provides a single shared dispatcher instance and safe concurrent access without changing the existing sorting/searching behavior.

- [ ] feat
- [ ] fix
- [x] perf
- [x] refactor
- [ ] docs
- [ ] enhance
- [x] test
- [ ] chore
## Implementation Details

* Added a process-wide `Dispatcher` singleton through `get_dispatcher()`.
* Added a dedicated `std::shared_mutex` to synchronize access to the global configuration.
* Configuration updates use `std::unique_lock` for exclusive write access.
* Read-only sorting/searching operations use `std::shared_lock` to allow concurrent readers.
* Changed `Dispatcher::config_` to hold a reference to the global `AlgoConfig`.
* Preserved the existing dispatcher behavior and public API while improving thread safety.

## Changes

- Added `get_dispatcher()`.
- Added `get_global_config_mutex()`.
- Added `std::shared_lock` for read-only dispatcher operations.
- Added `std::unique_lock` for configuration updates.
- Changed `Dispatcher::config_` to `AlgoConfig&`.


### Synchronization Model

* **Dispatcher instance:** Function-local static singleton
* **Configuration writes:** `std::unique_lock<std::shared_mutex>`
* **Sorting/searching reads:** `std::shared_lock<std::shared_mutex>`

### Complexity

* **Time Complexity:** Unchanged from existing sorting/searching algorithms
* **Auxiliary Space:** O(1) additional synchronization state apart from the mutex/singleton objects
* **Behavior:** No algorithmic behavior changes

Benchmarks & Performance Metrics : --- 

Benchmarks were executed using the same Release configuration and workload before and after the dispatcher changes.
The complete before/after benchmark output is attached below.

**Benchmark Result :** 

 1 > BEFORE ... : 

<img width="858" height="848" alt="Screenshot 2026-09-04 125219" src="https://github.com/user-attachments/assets/eefaa875-b37a-48f7-989b-61e1cd675e43" />

2 > AFTER .. : 

<img width="882" height="787" alt="Screenshot 2026-09-04 125240" src="https://github.com/user-attachments/assets/82a7bd12-d231-4029-952c-5750e1f22e4a" />

**Bench_Sorting :** 

<img width="928" height="854" alt="Screenshot 2026-09-04 015553" src="https://github.com/user-attachments/assets/8cbec704-a48f-4e50-b765-5fd381063df7" />


## Dependencies

None.

### Verification Results

*** Release build: **PASSED****

<img width="946" height="832" alt="Screenshot 2026-09-04 015518" src="https://github.com/user-attachments/assets/a44379b5-3ead-4a48-8d82-76c0ca7a55d9" />

----------------------------------------

<img width="2560" height="1822" alt="photo_2026-09-04_13-07-45" src="https://github.com/user-attachments/assets/a67aa6ec-05f4-4400-a26a-e743fa69afd5" />


*** Dispatcher unit tests: **6/6 PASSED**

<img width="816" height="758" alt="Screenshot 2026-09-04 120534" src="https://github.com/user-attachments/assets/c0be7254-3448-440c-ac3f-a73156bfc885" />




* Thread-safety verification: **8 threads × 100 iterations — PASSED**

<img width="1001" height="498" alt="Screenshot 2026-09-04 112028" src="https://github.com/user-attachments/assets/1deec6e4-b1aa-4d41-9074-af4fa20d4e26" />



* Benchmark target build: **PASSED**


<img width="884" height="789" alt="Screenshot 2026-09-04 114048" src="https://github.com/user-attachments/assets/774cac33-7904-4332-94cd-dbdac3577a3a" />


* `git diff --check`: **PASSED**
* `git diff --cached --check`: **PASSED****

**Developer Checklist**

- [x] My PR title follows `<Type>(<scope>): <Precise PR deliverable>`.
- [x] My branch was created from `main` using an approved prefix (`feat/`, `fix/`, `perf/`, etc.).
- [x] I have formatted my C++ code using `clang-format`.
- [x] My code produces no new compiler warnings or static analysis issues (`clang-tidy`).
- [x] I have added unit tests covering the new functionality or regression fix.
- [ ] I have updated documentation / docstrings where appropriate.
- [x] My changes do not break existing functionality.

**Impact Assessment**

- [x] Isolated
- [ ] Breaking / Affects Others

**Future Improvements**

Add dedicated multithreaded benchmarks to measure dispatcher contention under higher concurrency.
Further optimize synchronization granularity if future profiling identifies lock contention as a bottleneck.

**Mentions**

@Sambit003 
